### PR TITLE
Migrate build backend to hatchling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 __pycache__
 *.egg-info/
 *.pyc
+dist/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,23 @@
 [build-system]
-requires = ["setuptools"]
-build-backend = "setuptools.build_meta"
+requires = ["hatchling>=1.27.0"]
+build-backend = "hatchling.build"
 
-[tool.distutils.bdist_wheel]
-universal = true
+[project]
+name = "srt_fix"
+version = "1.1.0"
+requires-python = ">=3.10"
+readme = "README.md"
+license = "Unlicense"
+license-files = ["LICENSE"]
+
+[tool.hatch.build.targets.sdist]
+include = [
+    "/yt_dlp_plugins",
+    "/.gitignore",  # included by default, needed for auto-excludes
+    "/LICENSE",  # included as license
+    "/pyproject.toml",  # included by default
+    "/README.md",  # included as readme
+]
+
+[tool.hatch.build.targets.wheel]
+packages = ["yt_dlp_plugins"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,0 @@
-[metadata]
-name = srt_fix
-version = 2023.01.02
-
-[options]
-packages = find_namespace:


### PR DESCRIPTION
Building the plugin as a Python package (e.g. `pip install` or `python -m build`) is completely broken with the current setuptools config.

This PR migrates the build backend from setuptools to hatchling, and in doing so it fixes the build issue.

**NOTE:** The PR also bumps the Python package's version to `1.1.0`. This can be changed to anything you want, of course. But the version will need to be *changed* in order for `pip install` to actually be fixed.

Fixes #17